### PR TITLE
Remove reference to non-existant maven repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -8,13 +8,6 @@
   <name>bq-gettingstarted</name>
   <url>http://maven.apache.org</url>
 
-  <repositories>
-      <repository>
-          <id>googleapis</id>
-          <url>https://google-api-client-libraries.appspot.com/mavenrepo</url>
-      </repository>
-  </repositories>
-
   <dependencies>
     <dependency>
         <groupId>com.google.apis</groupId>


### PR DESCRIPTION
There is no maven repository at https://google-api-client-libraries.appspot.com/mavenrepo. The librares can be found at sonatype.org
